### PR TITLE
More helpful command line parsing

### DIFF
--- a/elyzer/__main__.py
+++ b/elyzer/__main__.py
@@ -4,10 +4,15 @@ from elyzer import stepWise, getAnalyzer
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--es', type=str)
-    parser.add_argument('--index', type=str)
-    parser.add_argument('--analyzer', type=str)
-    parser.add_argument('--text', type=str)
+    parser.add_argument('--es', type=str,
+                        help='Root URL to Elasticsearch, ie http://localhost:9200',
+                        default='http://localhost:9200')
+    parser.add_argument('--index', type=str, required=True,
+                        help='Name of the index to find the analyzer, ie tweets')
+    parser.add_argument('--analyzer', type=str, required=True,
+                        help='Name of the custom analyzer, ie my_text_analyzer')
+    parser.add_argument('--text', type=str, required=True,
+                        help='Text to analyze, ie "mary had a little lamb"')
     return vars(parser.parse_args())
 
 def main():


### PR DESCRIPTION
Previously, missing CLI args threw an unhelpful Python exception, so
I've indicated which arguments are required, which can be defaulted, and
added help text whet teh user types `elyzer --help`