### PR TITLE
Fixes #8 Upgrades elasticsearch dependency to 5.x

### DIFF
--- a/elyzer/elyzer.py
+++ b/elyzer/elyzer.py
@@ -62,13 +62,13 @@ def stepWise(text, indexName, analyzer, es):
         print("CHAR_FILTER: %s" % charFilter)
         charFiltersInUse.append(charFilter)
         analyzeResp = es.indices.analyze(index=indexName, body=text,
-                                             char_filters=",".join(charFiltersInUse))
+                                             char_filter=",".join(charFiltersInUse))
         printTokens(analyzeResp)
 
     # Add tokenizer
     print("TOKENIZER: %s" % tokenizer)
     analyzeResp = es.indices.analyze(index=indexName, body=text,
-                                     char_filters=",".join(charFiltersInUse),
+                                     char_filter=",".join(charFiltersInUse),
                                      tokenizer=tokenizer)
     printTokens(analyzeResp)
 
@@ -84,7 +84,7 @@ def stepWise(text, indexName, analyzer, es):
         print("TOKEN_FILTER: %s" % currFilter)
         filtersInUse.append(currFilter)
         analyzeResp = es.indices.analyze(index=indexName, body=text,
-                                         char_filters=",".join(charFiltersInUse),
-                                         filters=",".join(filtersInUse),
+                                         char_filter=",".join(charFiltersInUse),
+                                         filter=",".join(filtersInUse),
                                          tokenizer=tokenizer)
         printTokens(analyzeResp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 argparse==1.2.1
-elasticsearch==1.6.0
+elasticsearch==5.0.0
 urllib3==1.12
 wsgiref==0.1.2


### PR DESCRIPTION
- Old ES client libs used `char_filters` or were pretty tolerant
- 5.0 and after more strictly use `char_filter`... 

This upgrades the Elasticsearch dependency. Elyzer 0.3.0 will support ES 5 with older versions intended for ES 2.x and earlier.