### PR TITLE
Allow passing aliases to --index

### DIFF
--- a/elyzer/elyzer.py
+++ b/elyzer/elyzer.py
@@ -13,6 +13,10 @@ standard_analyzers = {
 class AnalyzerNotFound(Exception):
     pass
 
+class MultipleIndexesForAlias(Exception):
+    pass
+
+
 def listify(strVal):
     if (isinstance(strVal, str)):
         return [strVal]
@@ -42,12 +46,20 @@ def getAnalyzer(indexName, analyzerName, es):
 
     # otherwise try custom ones
     settings = es.indices.get_settings(index=indexName)
+
+    indexes = list(settings.values())
+    index_count = len(indexes)
+
+    if index_count > 1:
+      raise MultipleIndexesForAlias()
+
     try:
-        analyzer = settings[indexName]['settings']['index']['analysis']['analyzer'][analyzerName]
+        analyzer = indexes[0]['settings']['index']['analysis']['analyzer'][analyzerName]
         normalizeAnalyzer(analyzer)
         return analyzer
     except KeyError:
-        raise AnalyzerNotFound()
+      raise AnalyzerNotFound()
+
 
 def printTokens(analyzeResp):
     tokens = analyzeResp['tokens']


### PR DESCRIPTION
Currently if you pass an alias name to --index, elyzer throws an AnalyzerNotFound exception, which is a bit confusing because the analyzer does exist.

Here's an example:

```json
PUT test_index
{
  "settings": {
    "number_of_shards": 1,
    "number_of_replicas": 1,
    "analysis": {
      "analyzer": {
        "custom_analyzer": {
          "type": "custom",
          "tokenizer": "standard",
          "filter": [
            "lowercase",
            "asciifolding"
          ]
        }
      }
    }
  },
  "mappings": {
    "type1": {
      "properties": {
        "field1": {
          "type": "text"
        }
      }
    }
  }
}

POST /_aliases
{
    "actions" : [
        { "add" : { "index" : "test_index", "alias" : "test_alias" } }
    ]
}
```

```bash
$ elyzer --index test_index --analyzer custom_analyzer 'hello world'
TOKENIZER: standard
{0:hello}	{1:world}	
TOKEN_FILTER: lowercase
{0:hello}	{1:world}	
TOKEN_FILTER: asciifolding
{0:hello}	{1:world}	

$ elyzer --index test_alias --analyzer custom_analyzer 'hello world'
Traceback (most recent call last):
  File "/home/mat/code/elyzer/elyzer/elyzer/elyzer.py", line 46, in getAnalyzer
    analyzer = settings[indexName]['settings']['index']['analysis']['analyzer'][analyzerName]
KeyError: 'test_alias'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mat/.virtualenvs/elyzer-2J9T7zoA/bin/elyzer", line 11, in <module>
    load_entry_point('elyzer', 'console_scripts', 'elyzer')()
  File "/home/mat/code/elyzer/elyzer/elyzer/__main__.py", line 42, in main
    es=es))
  File "/home/mat/code/elyzer/elyzer/elyzer/elyzer.py", line 50, in getAnalyzer
    raise AnalyzerNotFound()
elyzer.elyzer.AnalyzerNotFound
```

Even though the get settings API supports passing an alias, the response is always keyed by index name, so elyzer hits a KeyError when looking for the alias name.

In the case where an alias points to a single index, we can just take whatever is returned instead of looking up the name in the response.

Passing anything that matches multiple indexes still throws an error - in this case I think the user should be more specific.